### PR TITLE
Fix an issue with phase factor in nonlocal force calculation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,10 @@
 ----------------
+Dec 22, 2021
+Name: Qimen Xu, Taehee Ko (Penn State University)
+* Fix an issue with phase factor in nonlocal force calculation.
+
+
+----------------
 Dec 21, 2021
 Name: Shashikant Kumar
 * Modify the slow tests in the test-suite

--- a/src/atomicForce.m
+++ b/src/atomicForce.m
@@ -387,13 +387,13 @@ for ks = 1:S.tnkpt*S.nspin
 		kpt = ks - S.tnkpt;
 	end
 
-	if (kpt(1) == 0 && kpt(2) == 0 && kpt(3) == 0)
+	kpt_vec = S.kptgrid(kpt,:);
+
+	if (max(abs(kpt_vec)) < 1e-8)
 		fac = 1.0;
 	else
 		fac = 1.0i;
 	end
-	
-	kpt_vec = S.kptgrid(kpt,:);
 
 	% Calculate gradient of psi    
 	Dpsi_x = blochGradient(S,kpt_vec,1)*S.psi(:,:,ks);

--- a/src/initialization.m
+++ b/src/initialization.m
@@ -1110,7 +1110,7 @@ end
 
 start_time = fix(clock);
 fprintf(fileID,'***************************************************************************\n');
-fprintf(fileID,'*                      M-SPARC v1.0.0 (Dec 18, 2021)                      *\n');
+fprintf(fileID,'*                      M-SPARC v1.0.0 (Dec 22, 2021)                      *\n');
 fprintf(fileID,'*   Copyright (c) 2019 Material Physics & Mechanics Group, Georgia Tech   *\n');
 fprintf(fileID,'*           Distributed under GNU General Public License 3 (GPL)          *\n');
 fprintf(fileID,'*                Date: %s  Start time: %02d:%02d:%02d                  *\n',date,start_time(4),start_time(5),start_time(6));


### PR DESCRIPTION
* In the nonlocal force calculation, `fac` was not correctly set to `1.0` instead of `1.0i` in the phase factor calculation for the Gamma-point. This fix will explicitly force Matlab  (for some versions) to use real operations instead of complex operations to do the calculation for the Gamma-point.
* Thanks to Taehee Ko (Penn State University) for pointing this out to us!
